### PR TITLE
Added multiprocessing to quantify.py

### DIFF
--- a/liqa_src/liqa.py
+++ b/liqa_src/liqa.py
@@ -39,8 +39,8 @@ def main():
             print("Please specify reference file format: gtf/ucsc")
 
     if task == "quantify":
-        validArgList = ["-task", "-refgene", "-bam", "-out", "-max_distance", "-f_weight"]
-        addAbsPath = [0, 1, 1, 3, 0, 0]
+        validArgList = ["-task", "-refgene", "-bam", "-out", "-max_distance", "-f_weight", "-threads"]
+        addAbsPath = [0, 1, 1, 3, 0, 0, 0]
         message = "liqa -task quantify -refgene <refgene_file> -bam <bam_file> -out <output_file> -max_distance <max distance> -f_weight <weight of F function>"
         inputs = my.parse_argument(validArgList, addAbsPath, message)
         refFile = inputs[1]
@@ -48,7 +48,8 @@ def main():
         outFile = inputs[3]
         misMatch = inputs[4]
         weightF = inputs[5]
-        myCommand = "python " + fileAbsPath + "/quantify.py -ref " + refFile + " -bam " +  bamFile + " -out " + outFile + " -mismatch " + misMatch + " -f_weight " + weightF
+        threads = inputs[6]
+        myCommand = "python " + fileAbsPath + "/quantify.py -ref " + refFile + " -bam " +  bamFile + " -out " + outFile + " -mismatch " + misMatch + " -f_weight " + weightF + " -threads " + threads
         #myCommand = "python " + "liqa_bin/quantify.py -ref " + refFile + " -bam " +  bamFile + " -out " + outFile + " -mismatch " + misMatch + " -f_weight " + weightF
         os.system(myCommand)
 


### PR DESCRIPTION
With this commit you can run `liqa -task quantify ... -threads <num>` to multi-thread `quantify` which is very slow on a single thread. I tested the new commit by using `diff` on the sorted old output, sorted new output with `-thread 1` and sorted new output with `-thread 32`. No lines were different:

```bash
$ diff <(sort THREAD_1.tsv ) <(sort THREAD_1_OLD.tsv ) | wc -l 
0
$ diff <(sort THREAD_1.tsv ) <(sort THREAD_32.tsv ) | wc -l
0
```